### PR TITLE
🌱 temp fix for azure aks node refs

### DIFF
--- a/controllers/noderefutil/providerid.go
+++ b/controllers/noderefutil/providerid.go
@@ -18,6 +18,7 @@ package noderefutil
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -43,6 +44,11 @@ type ProviderID struct {
 */
 var providerIDRegex = regexp.MustCompile("^[^:]+://.*[^/]$")
 
+const (
+	aws   = "aws"
+	azure = "azure"
+)
+
 // NewProviderID parses the input string and returns a new ProviderID.
 func NewProviderID(id string) (*ProviderID, error) {
 	if id == "" {
@@ -56,8 +62,17 @@ func NewProviderID(id string) (*ProviderID, error) {
 	colonIndex := strings.Index(id, ":")
 	cloudProvider := id[0:colonIndex]
 
-	lastSlashIndex := strings.LastIndex(id, "/")
-	instance := id[lastSlashIndex+1:]
+	instance := ""
+
+	switch cloudProvider {
+	case azure:
+		splitProviderId := strings.Split(id, "/")
+		vmssIndex := len(splitProviderId) - 3
+		instance = fmt.Sprintf("%s-%s", splitProviderId[vmssIndex], splitProviderId[vmssIndex+2])
+	default:
+		lastSlashIndex := strings.LastIndex(id, "/")
+		instance = id[lastSlashIndex+1:]
+	}
 
 	res := &ProviderID{
 		original:      id,

--- a/controllers/noderefutil/providerid_test.go
+++ b/controllers/noderefutil/providerid_test.go
@@ -22,33 +22,42 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const aws = "aws"
-
 func TestNewProviderID(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      string
-		expectedID string
+		name          string
+		input         string
+		cloudProvider string
+		expectedID    string
 	}{
 		{
-			name:       "2 slashes after colon, one segment",
-			input:      "aws://instance-id",
-			expectedID: "instance-id",
+			name:          "2 slashes after colon, one segment",
+			input:         "aws://instance-id",
+			cloudProvider: aws,
+			expectedID:    "instance-id",
 		},
 		{
-			name:       "more than 2 slashes after colon, one segment",
-			input:      "aws:////instance-id",
-			expectedID: "instance-id",
+			name:          "more than 2 slashes after colon, one segment",
+			input:         "aws:////instance-id",
+			cloudProvider: aws,
+			expectedID:    "instance-id",
 		},
 		{
-			name:       "multiple filled-in segments (aws format)",
-			input:      "aws:///zone/instance-id",
-			expectedID: "instance-id",
+			name:          "multiple filled-in segments (aws format)",
+			input:         "aws:///zone/instance-id",
+			cloudProvider: aws,
+			expectedID:    "instance-id",
 		},
 		{
-			name:       "multiple filled-in segments",
-			input:      "aws://bar/baz/instance-id",
-			expectedID: "instance-id",
+			name:          "multiple filled-in segments",
+			input:         "aws://bar/baz/instance-id",
+			cloudProvider: aws,
+			expectedID:    "instance-id",
+		},
+		{
+			name:          "multiple filled-in segments (aks format)",
+			input:         "azure:///subscriptions/<subscription-id>/resourceGroups/SPC_MC_-rg_capz-managed-aks_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workerpool0-39475182-vmss/virtualMachines/0",
+			cloudProvider: azure,
+			expectedID:    "aks-workerpool0-39475182-vmss-0",
 		},
 	}
 
@@ -58,7 +67,7 @@ func TestNewProviderID(t *testing.T) {
 
 			id, err := NewProviderID(tc.input)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(id.CloudProvider()).To(Equal(aws))
+			g.Expect(id.CloudProvider()).To(Equal(tc.cloudProvider))
 			g.Expect(id.ID()).To(Equal(tc.expectedID))
 		})
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

/kind bug

**What this PR does / why we need it**:
It provides a temporary fix for nodeRef issue in cluster-api. The current acceptance schema policy for providerId in cluster-api is rigid and specific to EKS. There is no guarantee that the exiting logic will work well for all the managedProviders as each provider might have its own representation/schema for a providerId.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # BET-2681, BET-2682

I tried reaching out tot the cluster-api folks but did not get any response.

