### PR TITLE
Additional changes for azure providerId

### DIFF
--- a/controllers/noderefutil/providerid.go
+++ b/controllers/noderefutil/providerid.go
@@ -65,7 +65,7 @@ func NewProviderID(id string) (*ProviderID, error) {
 
 	switch cloudProvider {
 	case azure:
-		instance = id
+		instance = strings.ToLower(id)
 	default:
 		lastSlashIndex := strings.LastIndex(id, "/")
 		instance = id[lastSlashIndex+1:]


### PR DESCRIPTION
cluster-api-azure is still not able to completely able to fix the issue 

Id set on node: `azure:///subscriptions/8710ff2b-e468-434a-9a84-e522999f6b81/resourceGroups/spc_mc_lochan-rg_azure-spc_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-workerppqeh-93709500-vmss/virtualMachines/0`

Id set on ammp: `azure:///subscriptions/8710ff2b-e468-434a-9a84-e522999f6b81/resourcegroups/spc_mc_lochan-rg_azure-spc_eastus/providers/microsoft.compute/virtualmachinescalesets/aks-workerppqeh-93709500-vmss/virtualmachines/0`