### PR TITLE
Support ControlPlaneKubeletLocalMode feature gate for k8sVersion >= 1.31.0

### DIFF
--- a/controlplane/kubeadm/internal/controllers/upgrade.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade.go
@@ -88,6 +88,10 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		if err := workloadCluster.UpdateImageRepositoryInKubeadmConfigMap(ctx, imageRepository, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update the image repository in the kubeadm config map")
 		}
+
+		if err := workloadCluster.UpdateFeatureGatesInKubeadmConfigMap(ctx, controlPlane.KCP.Spec.KubeadmConfigSpec, parsedVersionTolerant); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update feature gates in the kubeadm config map")
+		}
 	}
 
 	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil && kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {


### PR DESCRIPTION
Testing

- [x] Cluster launch with old version 1.30.x
- [ ] Cluster launch with 1.31.x
- [x] Cluster upgrade from 1.30.x to 1.31.x