### PR TITLE
PEM-4967: HACK - combine: use instanceID for providerID comparision

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -148,7 +148,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			continue
 		}
 
-		nodeRefsMap[nodeProviderID.String()] = node
+		nodeRefsMap[nodeProviderID.ID()] = node
 	}
 	for _, providerID := range providerIDList {
 		pid, err := noderefutil.NewProviderID(providerID)
@@ -156,7 +156,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		delete(nodeRefsMap, pid.String())
+		delete(nodeRefsMap, pid.ID())
 	}
 	for _, node := range nodeRefsMap {
 		if err := c.Delete(ctx, node); err != nil {

--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -184,7 +184,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 				continue
 			}
 
-			nodeRefsMap[nodeProviderID.String()] = node
+			nodeRefsMap[nodeProviderID.ID()] = node
 		}
 
 		if nodeList.Continue == "" {
@@ -199,7 +199,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		if node, ok := nodeRefsMap[pid.String()]; ok {
+		if node, ok := nodeRefsMap[pid.ID()]; ok {
 			available++
 			if nodeIsReady(&node) {
 				ready++


### PR DESCRIPTION
IMAGE - `gcr.io/spectro-dev-public/pavan/release/cluster-api-controller-amd64:v1.3.2-spectro-20250129-0015`

Updated Image: `gcr.io/spectro-dev-public/shubham/release/cluster-api-controller-amd64:v1.3.2-spectro-4.0.0-dev `