### PR TITLE
PCP-4630: Fix MachinePool nodeRef UID mismatch after K8s upgrade

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -65,8 +65,33 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, s *scope)
 	// Check that the Machine doesn't already have a NodeRefs.
 	// Return early if there is no work to do.
 	if mp.Status.Replicas == mp.Status.ReadyReplicas && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
-		conditions.MarkTrue(mp, expv1.ReplicasReadyCondition)
-		return ctrl.Result{}, nil
+		// Validate that the UIDs in NodeRefs are still valid
+		if s.nodeRefMap != nil {
+			// Create a name-to-node mapping for efficient lookup
+			nodeNameMap := make(map[string]*corev1.Node)
+			for _, node := range s.nodeRefMap {
+				nodeNameMap[node.Name] = node
+			}
+
+			validNodeRefs := true
+			for _, nodeRef := range mp.Status.NodeRefs {
+				foundNode, exists := nodeNameMap[nodeRef.Name]
+
+				// If node not found or UID doesn't match, mark as invalid
+				if !exists || foundNode.UID != nodeRef.UID {
+					validNodeRefs = false
+					break
+				}
+			}
+
+			if validNodeRefs {
+				conditions.MarkTrue(mp, expv1.ReplicasReadyCondition)
+				return ctrl.Result{}, nil
+			}
+		} else {
+			// If nodeRefMap is nil, we can't validate UIDs, so proceed with reconciliation
+			log.V(2).Info("NodeRefMap is nil, proceeding with reconciliation to validate NodeRefs")
+		}
 	}
 
 	// Check that the MachinePool has valid ProviderIDList.


### PR DESCRIPTION
**Issue:**
When a K8s upgrade is performed on a Managed cluster, new nodes will come up with new UIDs. However, the MachinePool controller has an early return condition that only validates the count of NodeRefs but doesn't check if the UIDs are still valid. This leads to MachinePools retaining stale NodeRef UIDs after upgrades, causing UID mismatches that persist until manual intervention.

**Fix:**
This PR adds UID validation logic before the early return condition. 
- A new name-to-node map with the name nodeNameMap is created. 
- We iterate over the mp.Status.NodeRefs and using the above map, get each each Node.
- If the Node doesn't exists or the fetched Node's UID is not matching to the UID in NodeRef, we break and continue with further reconciliation. This will set the correct nodeRef in the Machine Pool.