### PR TITLE
PCP-4630: Fix MachinePool nodeRef UID mismatch after K8s upgrade

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -65,8 +65,34 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, s *scope)
 	// Check that the Machine doesn't already have a NodeRefs.
 	// Return early if there is no work to do.
 	if mp.Status.Replicas == mp.Status.ReadyReplicas && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
-		conditions.MarkTrue(mp, expv1.ReplicasReadyCondition)
-		return ctrl.Result{}, nil
+		// Validate that the UIDs in NodeRefs are still valid
+		if s.nodeRefMap != nil {
+			// Create a name-to-node mapping for efficient lookup
+			nodeNameMap := make(map[string]*corev1.Node, len(s.nodeRefMap))
+			for _, node := range s.nodeRefMap {
+				nodeNameMap[node.Name] = node
+			}
+
+			validNodeRefs := true
+			for _, nodeRef := range mp.Status.NodeRefs {
+				foundNode, exists := nodeNameMap[nodeRef.Name]
+
+				// If node not found or UID doesn't match, mark as invalid
+				if !exists || foundNode.UID != nodeRef.UID {
+					log.V(1).Info("NodeRefs do not match current Nodes, will reassign")
+					validNodeRefs = false
+					break
+				}
+			}
+
+			if validNodeRefs {
+				conditions.MarkTrue(mp, expv1.ReplicasReadyCondition)
+				return ctrl.Result{}, nil
+			}
+		} else {
+			// If nodeRefMap is nil, we can't validate UIDs, so proceed with reconciliation
+			log.V(2).Info("NodeRefMap is nil, proceeding with reconciliation to validate NodeRefs")
+		}
 	}
 
 	// Check that the MachinePool has valid ProviderIDList.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->