### PR TITLE
PCP-7054: Bump Go builder to 1.26.4 to fix CVEs

### DIFF
--- a/.github/workflows/spectro-release.yaml
+++ b/.github/workflows/spectro-release.yaml
@@ -67,8 +67,8 @@ jobs:
         name: Build Image
         env:
           REGISTRY: ${{ env.LEGACY_REGISTRY }}
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
         run: |
           make docker-build-all
           make docker-push-all
@@ -76,8 +76,8 @@ jobs:
         name: Build Image - FIPS Mode
         env:
           REGISTRY: ${{ env.FIPS_REGISTRY }}
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
           FIPS_ENABLE: yes
           ALL_ARCH: amd64
         run: |

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.26.3
+GO_VERSION ?= 1.26.4
 GO_CONTAINER_IMAGE ?= us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang:${GO_VERSION}-alpine
 
 # Use GOPROXY environment variable if set
@@ -203,7 +203,7 @@ GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 # It is set by Prow GIT_TAG, a git-based tag of the form vYYYYMMDD-hash, e.g., v20210120-v0.3.10-308-gc61521971
 # Fips Flags
 FIPS_ENABLE ?= ""
-BUILDER_GOLANG_VERSION ?= 1.23
+BUILDER_GOLANG_VERSION ?= 1.26.4
 BUILD_ARGS = --build-arg CRYPTO_LIB=${FIPS_ENABLE} --build-arg BUILDER_GOLANG_VERSION=${BUILDER_GOLANG_VERSION}
 
 RELEASE_LOC := release


### PR DESCRIPTION
PCP-7054: Bump Go builder to 1.26.4 to fix CVEs